### PR TITLE
Hotfix: Specify database column

### DIFF
--- a/src/main/java/com/example/taskmanager/model/Task.java
+++ b/src/main/java/com/example/taskmanager/model/Task.java
@@ -18,6 +18,7 @@ public class Task {
     private Integer priority;
 
     @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "createdAt")
     private LocalDateTime createdAt;
 
     @OneToOne(cascade = CascadeType.PERSIST)


### PR DESCRIPTION
# Description

An issue occurred in production where the column was referencing CREATED_AT, instead of CREATEDAT